### PR TITLE
Add multiple query support to QueryMiddleware

### DIFF
--- a/docs/book/middleware.md
+++ b/docs/book/middleware.md
@@ -12,54 +12,52 @@ object. The data for the command is extracted from the body of the request (`$re
 array.
 
 ## QueryMiddleware
-The `QueryMiddleware` dispatches the message data to the query bus system. Unlike the other middleware, the
-`QueryMiddleware` supports sending multiple messages using a *POST* request.
+The `QueryMiddleware` is used to dispatch messages to the query bus system. Unlike the other middleware, the `QueryMiddleware`
+supports sending multiple messages. Each query
+is an object inside of the root `queries` object on the request payload and is indexed using a unique key. The response will include the query results
+for each query, indexed using the same key as the request.  An example request/response would look like:
 
-### Using GET
-
-Using *GET*, the `QueryMiddleware` only supports a single message. The `prooph_query_name` attribute must be present as
-an `attribute` on the request. Any additional query parameters will be added to the body of the message as well. An
-example URL template would be
-
-`GET /query/{prooph_query_name}`
-
-The resulting request might be
-
-`GET /query/users?name=John`
-
-And the parsed message array would end up as
-
-```php
-[
-    'prooph_query_name' => 'users',
-    'name' => 'John'
-]
-```
-
-
-### Using POST
-
-With a *POST* request, it is expected that the parsed body contain an array of messages. Each object of the array must
-contain the `prooph_query_name` property. All other information will be used when populating the the message object. An
-example JSON request might look something like
+**Request**
 
 `POST /query`
 
 ```json
-[
-    {
-        "prooph_query_name": "query:get-users",
-        "filter": [
-            "12"
-        ]
-    },
-    {
-        "prooph_query_name": "query:get-todos",
-        "status": [
-            "OPEN"
-        ]
+{
+    "queries": {
+        "getUsers": {
+            "prooph_query_name": "query:get-users",
+            "filter": [
+                "12"
+            ]
+        },
+        "getTodos": {
+            "prooph_query_name": "query:get-todos",
+            "status": [
+                "OPEN"
+            ]
+        }
     }
-]
+}
+```
+
+**Response**
+
+```json
+{
+    "getUsers": [
+        {
+            "username": "John"
+        }
+    ],
+    "getTodos": [
+        {
+            "task": "Write some docs"
+        },
+        {
+            "task": "Build cool things"
+        }
+    ]
+}
 ```
 
 ## EventMiddleware

--- a/tests/QueryMiddlewareTest.php
+++ b/tests/QueryMiddlewareTest.php
@@ -117,7 +117,9 @@ class QueryMiddlewareTest extends TestCase
 
         $queryBus = $this->prophesize(QueryBus::class);
         $queryBus->dispatch(Argument::type(Message::class))->shouldBeCalled()->willReturn(
-            new Promise(function () { return []; })
+            new Promise(function () {
+                return [];
+            })
         );
 
         $message = $this->prophesize(Message::class);
@@ -161,7 +163,9 @@ class QueryMiddlewareTest extends TestCase
 
         $queryBus = $this->prophesize(QueryBus::class);
         $queryBus->dispatch(Argument::type(Message::class))->shouldBeCalled()->willReturn(
-            new Promise(function () { return []; })
+            new Promise(function () {
+                return [];
+            })
         );
 
         $message = $this->prophesize(Message::class);
@@ -209,7 +213,9 @@ class QueryMiddlewareTest extends TestCase
 
         $queryBus = $this->prophesize(QueryBus::class);
         $queryBus->dispatch(Argument::type(Message::class))->shouldBeCalled()->willReturn(
-            new Promise(function () { return []; })
+            new Promise(function () {
+                return [];
+            })
         );
 
         $message = $this->prophesize(Message::class);

--- a/tests/QueryMiddlewareTest.php
+++ b/tests/QueryMiddlewareTest.php
@@ -25,6 +25,7 @@ use Prophecy\Argument;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use React\Promise\FulfilledPromise;
 use React\Promise\Promise;
 
 /**
@@ -117,9 +118,7 @@ class QueryMiddlewareTest extends TestCase
 
         $queryBus = $this->prophesize(QueryBus::class);
         $queryBus->dispatch(Argument::type(Message::class))->shouldBeCalled()->willReturn(
-            new Promise(function () {
-                return [];
-            })
+            new FulfilledPromise()
         );
 
         $message = $this->prophesize(Message::class);
@@ -162,11 +161,7 @@ class QueryMiddlewareTest extends TestCase
         $parsedBody = [['prooph_query_name' => $queryName, 'filter' => []]];
 
         $queryBus = $this->prophesize(QueryBus::class);
-        $queryBus->dispatch(Argument::type(Message::class))->shouldBeCalled()->willReturn(
-            new Promise(function () {
-                return [];
-            })
-        );
+        $queryBus->dispatch(Argument::type(Message::class))->shouldBeCalled()->willReturn(new FulfilledPromise([]));
 
         $message = $this->prophesize(Message::class);
 
@@ -207,16 +202,12 @@ class QueryMiddlewareTest extends TestCase
     {
         $queryName = 'stdClass';
         $parsedBody = [
-            ['prooph_query_name' => $queryName, 'filter' => []],
-            ['prooph_query_name' => $queryName, 'filter' => ['test']],
+            'one' => ['prooph_query_name' => $queryName, 'filter' => []],
+            'two' => ['prooph_query_name' => $queryName, 'filter' => ['test']],
         ];
 
         $queryBus = $this->prophesize(QueryBus::class);
-        $queryBus->dispatch(Argument::type(Message::class))->shouldBeCalled()->willReturn(
-            new Promise(function () {
-                return [];
-            })
-        );
+        $queryBus->dispatch(Argument::type(Message::class))->shouldBeCalled()->willReturn(new FulfilledPromise([]));
 
         $message = $this->prophesize(Message::class);
 

--- a/tests/QueryMiddlewareTest.php
+++ b/tests/QueryMiddlewareTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace ProophTest\HttpMiddleware;
 
+use Fig\Http\Message\RequestMethodInterface;
 use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\Message;
 use Prooph\Common\Messaging\MessageFactory;
@@ -45,6 +46,7 @@ class QueryMiddlewareTest extends TestCase
         $responseStrategy->fromPromise(Argument::type(Promise::class))->shouldNotBeCalled();
 
         $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethodInterface::METHOD_GET)->shouldBeCalled();
         $request->getAttribute(QueryMiddleware::NAME_ATTRIBUTE)->willReturn(null)->shouldBeCalled();
 
         $gatherer = $this->prophesize(MetadataGatherer::class);
@@ -79,7 +81,7 @@ class QueryMiddlewareTest extends TestCase
         $messageFactory
             ->createMessageFromArray(
                 $queryName,
-                ['payload' => $payload, 'metadata' => []]
+                ['prooph_query_name' => 'stdClass', 'user_id' => 123, 'metadata' => []]
             )
             ->willReturn($message->reveal())
             ->shouldBeCalled();
@@ -88,7 +90,7 @@ class QueryMiddlewareTest extends TestCase
         $responseStrategy->fromPromise(Argument::type(Promise::class))->shouldNotBeCalled();
 
         $request = $this->prophesize(ServerRequestInterface::class);
-        $request->getMethod()->shouldBeCalled();
+        $request->getMethod()->willReturn(RequestMethodInterface::METHOD_GET)->shouldBeCalled();
         $request->getQueryParams()->willReturn($payload)->shouldBeCalled();
         $request->getAttribute(QueryMiddleware::NAME_ATTRIBUTE)->willReturn($queryName)->shouldBeCalled();
 
@@ -124,13 +126,13 @@ class QueryMiddlewareTest extends TestCase
         $messageFactory
             ->createMessageFromArray(
                 $queryName,
-                ['payload' => $payload, 'metadata' => []]
+                ['prooph_query_name' => $queryName, 'user_id' => 123, 'metadata' => []]
             )
             ->willReturn($message->reveal())
             ->shouldBeCalled();
 
         $request = $this->prophesize(ServerRequestInterface::class);
-        $request->getMethod()->shouldBeCalled();
+        $request->getMethod()->willReturn(RequestMethodInterface::METHOD_GET)->shouldBeCalled();
         $request->getQueryParams()->willReturn($payload)->shouldBeCalled();
         $request->getAttribute(QueryMiddleware::NAME_ATTRIBUTE)->willReturn($queryName)->shouldBeCalled();
 
@@ -155,8 +157,7 @@ class QueryMiddlewareTest extends TestCase
     public function it_dispatches_the_query_with_post_data(): void
     {
         $queryName = 'stdClass';
-        $parsedBody = ['filter' => []];
-        $payload = ['user_id' => 123];
+        $parsedBody = [['prooph_query_name' => $queryName, 'filter' => []]];
 
         $queryBus = $this->prophesize(QueryBus::class);
         $queryBus->dispatch(Argument::type(Message::class))->shouldBeCalled()->willReturn(
@@ -169,7 +170,7 @@ class QueryMiddlewareTest extends TestCase
         $messageFactory
             ->createMessageFromArray(
                 $queryName,
-                ['payload' => array_merge($payload, ['data' => $parsedBody]), 'metadata' => []]
+                ['prooph_query_name' => $queryName, 'filter' => [], 'metadata' => []]
             )
             ->willReturn($message->reveal())
             ->shouldBeCalled();
@@ -177,8 +178,109 @@ class QueryMiddlewareTest extends TestCase
         $request = $this->prophesize(ServerRequestInterface::class);
         $request->getMethod()->willReturn('POST')->shouldBeCalled();
         $request->getParsedBody()->willReturn($parsedBody)->shouldBeCalled();
-        $request->getQueryParams()->willReturn($payload)->shouldBeCalled();
-        $request->getAttribute(QueryMiddleware::NAME_ATTRIBUTE)->willReturn($queryName)->shouldBeCalled();
+        $request->getQueryParams()->shouldNotBeCalled();
+        $request->getAttribute()->shouldNotBeCalled();
+
+        $response = $this->prophesize(ResponseInterface::class);
+
+        $responseStrategy = $this->prophesize(ResponseStrategy::class);
+        $responseStrategy->fromPromise(Argument::type(Promise::class))->willReturn($response);
+
+        $gatherer = $this->prophesize(MetadataGatherer::class);
+        $gatherer->getFromRequest($request)->shouldBeCalled();
+
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+
+        $middleware = new QueryMiddleware($queryBus->reveal(), $messageFactory->reveal(), $responseStrategy->reveal(), $gatherer->reveal());
+
+        $this->assertSame($response->reveal(), $middleware->process($request->reveal(), $handler->reveal()));
+    }
+
+    /**
+     * @test
+     */
+    public function it_dispatches_multiple_queries(): void
+    {
+        $queryName = 'stdClass';
+        $parsedBody = [
+            ['prooph_query_name' => $queryName, 'filter' => []],
+            ['prooph_query_name' => $queryName, 'filter' => ['test']],
+        ];
+
+        $queryBus = $this->prophesize(QueryBus::class);
+        $queryBus->dispatch(Argument::type(Message::class))->shouldBeCalled()->willReturn(
+            $this->prophesize(Promise::class)->reveal()
+        );
+
+        $message = $this->prophesize(Message::class);
+
+        $messageFactory = $this->prophesize(MessageFactory::class);
+        $messageFactory
+            ->createMessageFromArray(
+                $queryName,
+                ['prooph_query_name' => $queryName, 'filter' => [], 'metadata' => []]
+            )
+            ->willReturn($message->reveal())
+            ->shouldBeCalled();
+
+        $messageFactory
+            ->createMessageFromArray(
+                $queryName,
+                ['prooph_query_name' => $queryName, 'filter' => ['test'], 'metadata' => []]
+            )
+            ->willReturn($message->reveal())
+            ->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn('POST')->shouldBeCalled();
+        $request->getParsedBody()->willReturn($parsedBody)->shouldBeCalled();
+        $request->getQueryParams()->shouldNotBeCalled();
+        $request->getAttribute()->shouldNotBeCalled();
+
+        $response = $this->prophesize(ResponseInterface::class);
+
+        $responseStrategy = $this->prophesize(ResponseStrategy::class);
+        $responseStrategy->fromPromise(Argument::type(Promise::class))->willReturn($response);
+
+        $gatherer = $this->prophesize(MetadataGatherer::class);
+        $gatherer->getFromRequest($request)->shouldBeCalled();
+
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+
+        $middleware = new QueryMiddleware($queryBus->reveal(), $messageFactory->reveal(), $responseStrategy->reveal(), $gatherer->reveal());
+
+        $this->assertSame($response->reveal(), $middleware->process($request->reveal(), $handler->reveal()));
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_dispatch_exceptions(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        $queryName = 'stdClass';
+        $parsedBody = [['prooph_query_name' => $queryName, 'filter' => []]];
+
+        $queryBus = $this->prophesize(QueryBus::class);
+        $queryBus->dispatch(Argument::type(Message::class))->shouldBeCalled()->willThrow(new RuntimeException());
+
+        $message = $this->prophesize(Message::class);
+
+        $messageFactory = $this->prophesize(MessageFactory::class);
+        $messageFactory
+            ->createMessageFromArray(
+                $queryName,
+                ['prooph_query_name' => $queryName, 'filter' => [], 'metadata' => []]
+            )
+            ->willReturn($message->reveal())
+            ->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn('POST')->shouldBeCalled();
+        $request->getParsedBody()->willReturn($parsedBody)->shouldBeCalled();
+        $request->getQueryParams()->shouldNotBeCalled();
+        $request->getAttribute()->shouldNotBeCalled();
 
         $response = $this->prophesize(ResponseInterface::class);
 

--- a/tests/QueryMiddlewareTest.php
+++ b/tests/QueryMiddlewareTest.php
@@ -117,7 +117,7 @@ class QueryMiddlewareTest extends TestCase
 
         $queryBus = $this->prophesize(QueryBus::class);
         $queryBus->dispatch(Argument::type(Message::class))->shouldBeCalled()->willReturn(
-            $this->prophesize(Promise::class)->reveal()
+            new Promise(function () { return []; })
         );
 
         $message = $this->prophesize(Message::class);
@@ -161,7 +161,7 @@ class QueryMiddlewareTest extends TestCase
 
         $queryBus = $this->prophesize(QueryBus::class);
         $queryBus->dispatch(Argument::type(Message::class))->shouldBeCalled()->willReturn(
-            $this->prophesize(Promise::class)->reveal()
+            new Promise(function () { return []; })
         );
 
         $message = $this->prophesize(Message::class);
@@ -209,7 +209,7 @@ class QueryMiddlewareTest extends TestCase
 
         $queryBus = $this->prophesize(QueryBus::class);
         $queryBus->dispatch(Argument::type(Message::class))->shouldBeCalled()->willReturn(
-            $this->prophesize(Promise::class)->reveal()
+            new Promise(function () { return []; })
         );
 
         $message = $this->prophesize(Message::class);


### PR DESCRIPTION
Attempt at #12 .

I decided to stick with using the attribute name `prooph_query_message` such that userland code can still use `message_name` if they so choose. I also tried to make the middleware still work for either a `GET` or `POST` request, with only the `POST` supporting multiple queries at a time.  

Let me know what you think.  